### PR TITLE
Fix issues for Rooch

### DIFF
--- a/sources/MinterManager.move
+++ b/sources/MinterManager.move
@@ -130,6 +130,15 @@ module free_tunnel_rooch::minter_manager {
         event::emit(MinterCapRevoked { minterCapId });
     }
 
+    public entry fun destroyMinterCap<CoinType: key + store>(
+        _minter: &signer,
+        minterCapObj: Object<MinterCap<CoinType>>,
+    ) {
+        let minterCapId = object::id(&minterCapObj);
+        let MinterCap<CoinType> { managerId: _ } = object::remove(minterCapObj);
+        event::emit(MinterCapDestroyed { minterCapId });
+    }
+
 
     // =========================== Minter Functions ===========================
     public entry fun mint<CoinType: key + store>(
@@ -184,15 +193,6 @@ module free_tunnel_rooch::minter_manager {
             ETREASURY_CAP_MANAGER_DESTROYED,
         );
         coin::burn(&mut treasuryCapManager.coinInfoObj, coinToBurn);
-    }
-
-    public entry fun destroyMinterCap<CoinType: key + store>(
-        _minter: &signer,
-        minterCapObj: Object<MinterCap<CoinType>>,
-    ) {
-        let minterCapId = object::id(&minterCapObj);
-        let MinterCap<CoinType> { managerId: _ } = object::remove(minterCapObj);
-        event::emit(MinterCapDestroyed { minterCapId });
     }
 
 

--- a/sources/Permissions.move
+++ b/sources/Permissions.move
@@ -146,8 +146,10 @@ module free_tunnel_rooch::permissions {
     public(friend) fun initExecutorsInternal(executors: vector<vector<u8>>, threshold: u64) {
         let storeP = account::borrow_mut_resource<PermissionsStorage>(@free_tunnel_rooch);
         assertEthAddressList(&executors);
+        assert!(threshold <= vector::length(&executors), ENOT_MEET_THRESHOLD);
         assert!(vector::length(&storeP._exeActiveSinceForIndex) == 0, EEXECUTORS_ALREADY_INITIALIZED);
         assert!(threshold > 0, ETHRESHOLD_MUST_BE_GREATER_THAN_ZERO);
+        checkExecutorsNotDuplicated(executors);
         vector::push_back(&mut storeP._executorsForIndex, executors);
         vector::push_back(&mut storeP._exeThresholdForIndex, threshold);
         vector::push_back(&mut storeP._exeActiveSinceForIndex, 1);
@@ -165,6 +167,7 @@ module free_tunnel_rooch::permissions {
     ) {
         assertEthAddressList(&newExecutors);
         assert!(threshold > 0, ETHRESHOLD_MUST_BE_GREATER_THAN_ZERO);
+        assert!(threshold <= vector::length(&newExecutors), ENOT_MEET_THRESHOLD);
         assert!(
             activeSince > now_seconds() + 36 * 3600,  // 36 hours
             EACTIVE_SINCE_SHOULD_AFTER_36H,
@@ -173,6 +176,7 @@ module free_tunnel_rooch::permissions {
             activeSince < now_seconds() + 120 * 3600,  // 5 days
             EACTIVE_SINCE_SHOULD_WITHIN_5D,
         );
+        checkExecutorsNotDuplicated(newExecutors);
 
         let msg = vector::empty<u8>();
         vector::append(&mut msg, ETH_SIGN_HEADER());
@@ -282,10 +286,26 @@ module free_tunnel_rooch::permissions {
         };
     }
 
+    fun checkExecutorsNotDuplicated(executors: vector<vector<u8>>) {
+        let i = 0;
+        while (i < vector::length(&executors)) {
+            let executor = *vector::borrow(&executors, i);
+            let j = 0;
+            while (j < i) {
+                assert!(*vector::borrow(&executors, j) != executor, EDUPLICATED_EXECUTORS);
+                j = j + 1;
+            };
+            i = i + 1;
+        };
+    }
+
     fun checkExecutorsForIndex(executors: &vector<vector<u8>>, exeIndex: u64) {
         let storeP = account::borrow_mut_resource<PermissionsStorage>(@free_tunnel_rooch);
         assertEthAddressList(executors);
-        assert!(vector::length(&storeP._exeActiveSinceForIndex) > exeIndex + 1, ENOT_MEET_THRESHOLD);
+        assert!(
+            vector::length(executors) >= *vector::borrow(&storeP._exeThresholdForIndex, exeIndex), 
+            ENOT_MEET_THRESHOLD
+        );
         let activeSince = *vector::borrow(&storeP._exeActiveSinceForIndex, exeIndex);
         assert!(activeSince < now_seconds(), EEXECUTORS_NOT_YET_ACTIVE);
 

--- a/sources/Permissions.move
+++ b/sources/Permissions.move
@@ -136,7 +136,7 @@ module free_tunnel_rooch::permissions {
         let len = vector::length(&storeP._proposerList);
         if (index < len) {
             let lastProposer = *vector::borrow(&storeP._proposerList, len - 1);
-            *vector::borrow_mut(&mut storeP._proposerList, index) = lastProposer;
+            *vector::borrow_mut(&mut storeP._proposerList, index - 1) = lastProposer;
             *table::borrow_mut(&mut storeP._proposerIndex, lastProposer) = index;
         };
         vector::pop_back(&mut storeP._proposerList);

--- a/sources/Permissions.move
+++ b/sources/Permissions.move
@@ -86,6 +86,14 @@ module free_tunnel_rooch::permissions {
         proposer: address,
     }
 
+    #[event]
+    struct ExecutorsUpdated has drop, copy {
+        executors: vector<vector<u8>>,
+        threshold: u64,
+        activeSince: u64,
+        exeIndex: u64,
+    }
+
 
     // =========================== Functions ===========================
     public(friend) fun assertOnlyAdmin(sender: &signer) {
@@ -153,6 +161,7 @@ module free_tunnel_rooch::permissions {
         vector::push_back(&mut storeP._executorsForIndex, executors);
         vector::push_back(&mut storeP._exeThresholdForIndex, threshold);
         vector::push_back(&mut storeP._exeActiveSinceForIndex, 1);
+        event::emit(ExecutorsUpdated { executors, threshold, activeSince: 1, exeIndex: 0 });
     }
 
     public entry fun updateExecutors(
@@ -222,7 +231,8 @@ module free_tunnel_rooch::permissions {
             *vector::borrow_mut(&mut storeP._executorsForIndex, newIndex) = newExecutors;
             *vector::borrow_mut(&mut storeP._exeThresholdForIndex, newIndex) = threshold;
             *vector::borrow_mut(&mut storeP._exeActiveSinceForIndex, newIndex) = activeSince;
-        }
+        };
+        event::emit(ExecutorsUpdated { executors: newExecutors, threshold, activeSince, exeIndex: newIndex });
     }
 
 

--- a/sources/lock/AtomicLockContract.move
+++ b/sources/lock/AtomicLockContract.move
@@ -29,13 +29,13 @@ module free_tunnel_rooch::atomic_lock {
 
 
     // ============================ Storage ===========================
-    struct AtomicLockGeneralStorage has key, store {
+    struct AtomicLockStorage has key, store {
         proposedLock: table::Table<vector<u8>, address>,
         proposedUnlock: table::Table<vector<u8>, address>,
         lockedBalanceOf: table::Table<u8, u256>,
     }
 
-    struct StoreForCoin<phantom CoinType: key + store> has key {
+    struct CoinStorage<phantom CoinType: key + store> has key {
         lockedCoins: Object<CoinStore<CoinType>>,
     }
 
@@ -76,12 +76,12 @@ module free_tunnel_rooch::atomic_lock {
     }
 
     fun init(admin: &signer) {
-        let atomicLockGeneralStorage = AtomicLockGeneralStorage {
+        let atomicLockStorage = AtomicLockStorage {
             proposedLock: table::new(),
             proposedUnlock: table::new(),
             lockedBalanceOf: table::new(),
         };
-        account::move_resource_to(admin, atomicLockGeneralStorage);
+        account::move_resource_to(admin, atomicLockStorage);
     }
 
 
@@ -93,10 +93,10 @@ module free_tunnel_rooch::atomic_lock {
     ) {
         permissions::assertOnlyAdmin(admin);
         req_helpers::addTokenInternal<CoinType>(tokenIndex, decimals);
-        let storeForCoin = StoreForCoin<CoinType> {
+        let coinStorage = CoinStorage<CoinType> {
             lockedCoins: coin_store::create_coin_store<CoinType>()
         };
-        account::move_resource_to(admin, storeForCoin);
+        account::move_resource_to(admin, coinStorage);
     }
 
 
@@ -106,9 +106,9 @@ module free_tunnel_rooch::atomic_lock {
     ) {
         permissions::assertOnlyAdmin(admin);
         req_helpers::removeTokenInternal(tokenIndex);
-        let StoreForCoin { 
+        let CoinStorage { 
             lockedCoins: lockedCoinsStoreObject
-        } = account::move_resource_from<StoreForCoin<CoinType>>(@free_tunnel_rooch);
+        } = account::move_resource_from<CoinStorage<CoinType>>(@free_tunnel_rooch);
         let lockedCoins = coin_store::remove_coin_store<CoinType>(lockedCoinsStoreObject);
         account_coin_store::deposit(signer::address_of(admin), lockedCoins);
     }
@@ -118,7 +118,7 @@ module free_tunnel_rooch::atomic_lock {
         proposer: &signer,
         reqId: vector<u8>,
     ) {
-        let storeA = account::borrow_mut_resource<AtomicLockGeneralStorage>(@free_tunnel_rooch);
+        let storeA = account::borrow_mut_resource<AtomicLockStorage>(@free_tunnel_rooch);
         req_helpers::assertFromChainOnly(&reqId);
         req_helpers::checkCreatedTimeFrom(&reqId);
         let action = req_helpers::actionFrom(&reqId);
@@ -132,9 +132,9 @@ module free_tunnel_rooch::atomic_lock {
         let _tokenIndex = req_helpers::tokenIndexFrom<CoinType>(&reqId);
         table::add(&mut storeA.proposedLock, reqId, proposerAddress);
 
-        let storeForCoin = account::borrow_mut_resource<StoreForCoin<CoinType>>(@free_tunnel_rooch);
+        let coinStorage = account::borrow_mut_resource<CoinStorage<CoinType>>(@free_tunnel_rooch);
         let coinToLock = account_coin_store::withdraw<CoinType>(proposer, amount);
-        coin_store::deposit(&mut storeForCoin.lockedCoins, coinToLock);
+        coin_store::deposit(&mut coinStorage.lockedCoins, coinToLock);
         event::emit(TokenLockProposed{ reqId, proposer: proposerAddress });
     }
     
@@ -147,7 +147,7 @@ module free_tunnel_rooch::atomic_lock {
         executors: vector<vector<u8>>,
         exeIndex: u64,
     ) {
-        let storeA = account::borrow_mut_resource<AtomicLockGeneralStorage>(@free_tunnel_rooch);
+        let storeA = account::borrow_mut_resource<AtomicLockStorage>(@free_tunnel_rooch);
         let proposerAddress = *table::borrow(&storeA.proposedLock, reqId);
         assert!(proposerAddress != EXECUTED_PLACEHOLDER, EINVALID_REQ_ID);
 
@@ -175,7 +175,7 @@ module free_tunnel_rooch::atomic_lock {
         _sender: &signer,
         reqId: vector<u8>,
     ) {
-        let storeA = account::borrow_mut_resource<AtomicLockGeneralStorage>(@free_tunnel_rooch);
+        let storeA = account::borrow_mut_resource<AtomicLockStorage>(@free_tunnel_rooch);
         let proposerAddress = *table::borrow(&storeA.proposedLock, reqId);
         assert!(proposerAddress != EXECUTED_PLACEHOLDER, EINVALID_REQ_ID);
         assert!(
@@ -187,8 +187,8 @@ module free_tunnel_rooch::atomic_lock {
         let amount = req_helpers::amountFrom<CoinType>(&reqId);
         let _tokenIndex = req_helpers::tokenIndexFrom<CoinType>(&reqId);
         
-        let storeForCoin = account::borrow_mut_resource<StoreForCoin<CoinType>>(@free_tunnel_rooch);
-        let coinInside = &mut storeForCoin.lockedCoins;
+        let coinStorage = account::borrow_mut_resource<CoinStorage<CoinType>>(@free_tunnel_rooch);
+        let coinInside = &mut coinStorage.lockedCoins;
         let coinCancelled = coin_store::withdraw(coinInside, amount);
 
         account_coin_store::deposit(proposerAddress, coinCancelled);
@@ -201,7 +201,7 @@ module free_tunnel_rooch::atomic_lock {
         reqId: vector<u8>,
         recipient: address,
     ) {
-        let storeA = account::borrow_mut_resource<AtomicLockGeneralStorage>(@free_tunnel_rooch);
+        let storeA = account::borrow_mut_resource<AtomicLockStorage>(@free_tunnel_rooch);
         permissions::assertOnlyProposer(proposer);
         req_helpers::assertFromChainOnly(&reqId);
         req_helpers::checkCreatedTimeFrom(&reqId);
@@ -226,7 +226,7 @@ module free_tunnel_rooch::atomic_lock {
         executors: vector<vector<u8>>,
         exeIndex: u64,
     ) {
-        let storeA = account::borrow_mut_resource<AtomicLockGeneralStorage>(@free_tunnel_rooch);
+        let storeA = account::borrow_mut_resource<AtomicLockStorage>(@free_tunnel_rooch);
         let recipient = *table::borrow(&storeA.proposedUnlock, reqId);
         assert!(recipient != EXECUTED_PLACEHOLDER, EINVALID_REQ_ID);
 
@@ -240,8 +240,8 @@ module free_tunnel_rooch::atomic_lock {
         let amount = req_helpers::amountFrom<CoinType>(&reqId);
         let _tokenIndex = req_helpers::tokenIndexFrom<CoinType>(&reqId);
 
-        let storeForCoin = account::borrow_mut_resource<StoreForCoin<CoinType>>(@free_tunnel_rooch);
-        let coinInside = &mut storeForCoin.lockedCoins;
+        let coinStorage = account::borrow_mut_resource<CoinStorage<CoinType>>(@free_tunnel_rooch);
+        let coinInside = &mut coinStorage.lockedCoins;
         let coinUnlocked = coin_store::withdraw(coinInside, amount);
 
         account_coin_store::deposit(recipient, coinUnlocked);
@@ -253,7 +253,7 @@ module free_tunnel_rooch::atomic_lock {
         _sender: &signer,
         reqId: vector<u8>,
     ) {
-        let storeA = account::borrow_mut_resource<AtomicLockGeneralStorage>(@free_tunnel_rooch);
+        let storeA = account::borrow_mut_resource<AtomicLockStorage>(@free_tunnel_rooch);
         let recipient = *table::borrow(&storeA.proposedUnlock, reqId);
         assert!(recipient != EXECUTED_PLACEHOLDER, EINVALID_REQ_ID);
         assert!(

--- a/sources/lock/AtomicLockContract.move
+++ b/sources/lock/AtomicLockContract.move
@@ -93,12 +93,14 @@ module free_tunnel_rooch::atomic_lock {
     ) {
         permissions::assertOnlyAdmin(admin);
         req_helpers::addTokenInternal<CoinType>(tokenIndex, decimals);
-        let coinStorage = CoinStorage<CoinType> {
-            lockedCoins: coin_store::create_coin_store<CoinType>()
-        };
-        account::move_resource_to(admin, coinStorage);
+        if (!account::exists_resource<CoinStorage<CoinType>>(@free_tunnel_rooch)) {
+            let coinStorage = CoinStorage<CoinType> {
+                lockedCoins: coin_store::create_coin_store<CoinType>()
+            };
+            account::move_resource_to(admin, coinStorage);
+        }
     }
-
+    
 
     public entry fun removeToken<CoinType: key + store>(
         admin: &signer,
@@ -106,11 +108,6 @@ module free_tunnel_rooch::atomic_lock {
     ) {
         permissions::assertOnlyAdmin(admin);
         req_helpers::removeTokenInternal(tokenIndex);
-        let CoinStorage { 
-            lockedCoins: lockedCoinsStoreObject
-        } = account::move_resource_from<CoinStorage<CoinType>>(@free_tunnel_rooch);
-        let lockedCoins = coin_store::remove_coin_store<CoinType>(lockedCoinsStoreObject);
-        account_coin_store::deposit(signer::address_of(admin), lockedCoins);
     }
 
 

--- a/sources/lock/AtomicLockContract.move
+++ b/sources/lock/AtomicLockContract.move
@@ -123,7 +123,7 @@ module free_tunnel_rooch::atomic_lock {
         req_helpers::checkCreatedTimeFrom(&reqId);
         let action = req_helpers::actionFrom(&reqId);
         assert!(action & 0x0f == 1, ENOT_LOCK_MINT);
-        assert!(table::contains(&storeA.proposedLock, reqId), EINVALID_REQ_ID);
+        assert!(!table::contains(&storeA.proposedLock, reqId), EINVALID_REQ_ID);
 
         let proposerAddress = signer::address_of(proposer);
         assert!(proposerAddress != EXECUTED_PLACEHOLDER, EINVALID_PROPOSER);

--- a/sources/mint/AtomicMintContract.move
+++ b/sources/mint/AtomicMintContract.move
@@ -165,7 +165,7 @@ module free_tunnel_rooch::atomic_mint {
     ) {
         req_helpers::checkCreatedTimeFrom(&reqId);
         let storeA = account::borrow_mut_resource<AtomicMintGeneralStorage>(@free_tunnel_rooch);
-        assert!(table::contains(&storeA.proposedMint, reqId), EINVALID_REQ_ID);
+        assert!(!table::contains(&storeA.proposedMint, reqId), EINVALID_REQ_ID);
         assert!(recipient != EXECUTED_PLACEHOLDER, EINVALID_RECIPIENT);
 
         req_helpers::amountFrom<CoinType>(&reqId);
@@ -241,7 +241,7 @@ module free_tunnel_rooch::atomic_mint {
         proposer: &signer,
         reqId: vector<u8>,
     ) {
-        req_helpers::assertToChainOnly(&reqId);
+        req_helpers::assertFromChainOnly(&reqId);
         assert!(req_helpers::actionFrom(&reqId) & 0x0f == 3, ENOT_BURN_MINT);
         proposeBurnPrivate<CoinType>(proposer, reqId);
     }

--- a/sources/mint/AtomicMintContract.move
+++ b/sources/mint/AtomicMintContract.move
@@ -33,14 +33,14 @@ module free_tunnel_rooch::atomic_mint {
 
 
     // ============================ Storage ===========================
-    struct AtomicMintGeneralStorage has key {
+    struct AtomicMintStorage has key {
         proposedMint: table::Table<vector<u8>, address>,
         proposedBurn: table::Table<vector<u8>, address>,
     }
 
-    struct StoreForCoinAndMinterCap<phantom CoinType: key + store> has key {
+    struct CoinStorage<phantom CoinType: key + store> has key {
         burningCoins: Object<CoinStore<CoinType>>,
-        minterCapOptObj: Option<Object<MinterCap<CoinType>>>,
+        minterCap: Option<Object<MinterCap<CoinType>>>,
     }
 
     #[event]
@@ -80,11 +80,11 @@ module free_tunnel_rooch::atomic_mint {
     }
 
     fun init(admin: &signer) {
-        let atomicMintGeneralStorage = AtomicMintGeneralStorage {
+        let atomicMintStorage = AtomicMintStorage {
             proposedMint: table::new(),
             proposedBurn: table::new(),
         };
-        account::move_resource_to(admin, atomicMintGeneralStorage);
+        account::move_resource_to(admin, atomicMintStorage);
     }
 
 
@@ -96,11 +96,11 @@ module free_tunnel_rooch::atomic_mint {
     ) {
         permissions::assertOnlyAdmin(admin);
         req_helpers::addTokenInternal<CoinType>(tokenIndex, decimals);
-        let storeForCoinAndMinterCap = StoreForCoinAndMinterCap<CoinType> {
+        let coinStorage = CoinStorage<CoinType> {
             burningCoins: coin_store::create_coin_store<CoinType>(),
-            minterCapOptObj: option::none(),
+            minterCap: option::none(),
         };
-        account::move_resource_to(admin, storeForCoinAndMinterCap);
+        account::move_resource_to(admin, coinStorage);
     }
 
 
@@ -110,9 +110,9 @@ module free_tunnel_rooch::atomic_mint {
         minterCapObj: Object<MinterCap<CoinType>>,
     ) {
         req_helpers::checkTokenType<CoinType>(tokenIndex);
-        let storeForCoinAndMinterCap = 
-            account::borrow_mut_resource<StoreForCoinAndMinterCap<CoinType>>(@free_tunnel_rooch);
-        option::fill(&mut storeForCoinAndMinterCap.minterCapOptObj, minterCapObj);
+        let coinStorage = 
+            account::borrow_mut_resource<CoinStorage<CoinType>>(@free_tunnel_rooch);
+        option::fill(&mut coinStorage.minterCap, minterCapObj);
     }
 
 
@@ -122,16 +122,16 @@ module free_tunnel_rooch::atomic_mint {
     ) {
         permissions::assertOnlyAdmin(admin);
         req_helpers::removeTokenInternal(tokenIndex);
-        let StoreForCoinAndMinterCap { burningCoins: burningCoinStoreObj, minterCapOptObj } = 
-            account::move_resource_from<StoreForCoinAndMinterCap<CoinType>>(@free_tunnel_rooch);
+        let CoinStorage { burningCoins: burningCoinStoreObj, minterCap } = 
+            account::move_resource_from<CoinStorage<CoinType>>(@free_tunnel_rooch);
         let burningCoins = coin_store::remove_coin_store<CoinType>(burningCoinStoreObj);
         account_coin_store::deposit(signer::address_of(admin), burningCoins);
 
-        if (option::is_some(&minterCapOptObj)) {
-            let minterCapObj = option::extract(&mut minterCapOptObj);
+        if (option::is_some(&minterCap)) {
+            let minterCapObj = option::extract(&mut minterCap);
             minter_manager::destroyMinterCap(admin, minterCapObj);
         };
-        option::destroy_none(minterCapOptObj);
+        option::destroy_none(minterCap);
     }
 
 
@@ -164,7 +164,7 @@ module free_tunnel_rooch::atomic_mint {
         recipient: address,
     ) {
         req_helpers::checkCreatedTimeFrom(&reqId);
-        let storeA = account::borrow_mut_resource<AtomicMintGeneralStorage>(@free_tunnel_rooch);
+        let storeA = account::borrow_mut_resource<AtomicMintStorage>(@free_tunnel_rooch);
         assert!(!table::contains(&storeA.proposedMint, reqId), EINVALID_REQ_ID);
         assert!(recipient != EXECUTED_PLACEHOLDER, EINVALID_RECIPIENT);
 
@@ -185,7 +185,7 @@ module free_tunnel_rooch::atomic_mint {
         exeIndex: u64,
         treasuryCapManagerObj: &mut Object<TreasuryCapManager<CoinType>>,
     ) {
-        let storeA = account::borrow_mut_resource<AtomicMintGeneralStorage>(@free_tunnel_rooch);
+        let storeA = account::borrow_mut_resource<AtomicMintStorage>(@free_tunnel_rooch);
         let recipient = *table::borrow(&storeA.proposedMint, reqId);
         assert!(recipient != EXECUTED_PLACEHOLDER, EINVALID_REQ_ID);
 
@@ -199,9 +199,9 @@ module free_tunnel_rooch::atomic_mint {
         let amount = req_helpers::amountFrom<CoinType>(&reqId);
         let _tokenIndex = req_helpers::tokenIndexFrom<CoinType>(&reqId);
 
-        let storeForCoinAndMinterCap = 
-            account::borrow_mut_resource<StoreForCoinAndMinterCap<CoinType>>(@free_tunnel_rooch);
-        let minterCapObj = option::borrow_mut(&mut storeForCoinAndMinterCap.minterCapOptObj);
+        let coinStorage = 
+            account::borrow_mut_resource<CoinStorage<CoinType>>(@free_tunnel_rooch);
+        let minterCapObj = option::borrow_mut(&mut coinStorage.minterCap);
         minter_manager::mint<CoinType>(
             sender, treasuryCapManagerObj, 
             minterCapObj, amount, recipient
@@ -214,7 +214,7 @@ module free_tunnel_rooch::atomic_mint {
         _sender: &signer,
         reqId: vector<u8>,
     ) {
-        let storeA = account::borrow_mut_resource<AtomicMintGeneralStorage>(@free_tunnel_rooch);
+        let storeA = account::borrow_mut_resource<AtomicMintStorage>(@free_tunnel_rooch);
         let recipient = *table::borrow(&storeA.proposedMint, reqId);
         assert!(recipient != EXECUTED_PLACEHOLDER, EINVALID_REQ_ID);
         assert!(
@@ -251,7 +251,7 @@ module free_tunnel_rooch::atomic_mint {
         proposer: &signer,
         reqId: vector<u8>,
     ) {
-        let storeA = account::borrow_mut_resource<AtomicMintGeneralStorage>(@free_tunnel_rooch);
+        let storeA = account::borrow_mut_resource<AtomicMintStorage>(@free_tunnel_rooch);
         req_helpers::checkCreatedTimeFrom(&reqId);
         assert!(!table::contains(&storeA.proposedBurn, reqId), EINVALID_REQ_ID);
 
@@ -262,10 +262,10 @@ module free_tunnel_rooch::atomic_mint {
         let _tokenIndex = req_helpers::tokenIndexFrom<CoinType>(&reqId);
         table::add(&mut storeA.proposedBurn, reqId, proposerAddress);
         
-        let storeForCoinAndMinterCap = 
-            account::borrow_mut_resource<StoreForCoinAndMinterCap<CoinType>>(@free_tunnel_rooch);
+        let coinStorage = 
+            account::borrow_mut_resource<CoinStorage<CoinType>>(@free_tunnel_rooch);
         let coinToBurn = account_coin_store::withdraw(proposer, amount);
-        coin_store::deposit(&mut storeForCoinAndMinterCap.burningCoins, coinToBurn);
+        coin_store::deposit(&mut coinStorage.burningCoins, coinToBurn);
         event::emit(TokenBurnProposed{ reqId, proposer: proposerAddress });
     }
 
@@ -279,8 +279,8 @@ module free_tunnel_rooch::atomic_mint {
         exeIndex: u64,
         treasuryCapManagerObj: &mut Object<TreasuryCapManager<CoinType>>,
     ) {
-        let storeA = account::borrow_mut_resource<AtomicMintGeneralStorage>(@free_tunnel_rooch);
-        let storeForCoinAndMinterCap = account::borrow_mut_resource<StoreForCoinAndMinterCap<CoinType>>(@free_tunnel_rooch);
+        let storeA = account::borrow_mut_resource<AtomicMintStorage>(@free_tunnel_rooch);
+        let coinStorage = account::borrow_mut_resource<CoinStorage<CoinType>>(@free_tunnel_rooch);
 
         let proposerAddress = *table::borrow(&storeA.proposedBurn, reqId);
         assert!(proposerAddress != EXECUTED_PLACEHOLDER, EINVALID_REQ_ID);
@@ -295,10 +295,10 @@ module free_tunnel_rooch::atomic_mint {
         let amount = req_helpers::amountFrom<CoinType>(&reqId);
         let _tokenIndex = req_helpers::tokenIndexFrom<CoinType>(&reqId);
 
-        let coinInside = &mut storeForCoinAndMinterCap.burningCoins;
+        let coinInside = &mut coinStorage.burningCoins;
         let coinBurned = coin_store::withdraw(coinInside, amount);
 
-        let minterCapObj = option::borrow_mut(&mut storeForCoinAndMinterCap.minterCapOptObj);
+        let minterCapObj = option::borrow_mut(&mut coinStorage.minterCap);
         minter_manager::burn<CoinType>(
             _sender, treasuryCapManagerObj, minterCapObj, coinBurned
         );
@@ -309,8 +309,8 @@ module free_tunnel_rooch::atomic_mint {
     public entry fun cancelBurn<CoinType: key + store>(
         reqId: vector<u8>,
     ) {
-        let storeA = account::borrow_mut_resource<AtomicMintGeneralStorage>(@free_tunnel_rooch);
-        let storeForCoinAndMinterCap = account::borrow_mut_resource<StoreForCoinAndMinterCap<CoinType>>(@free_tunnel_rooch);
+        let storeA = account::borrow_mut_resource<AtomicMintStorage>(@free_tunnel_rooch);
+        let coinStorage = account::borrow_mut_resource<CoinStorage<CoinType>>(@free_tunnel_rooch);
 
         let proposerAddress = *table::borrow(&storeA.proposedBurn, reqId);
         assert!(proposerAddress != EXECUTED_PLACEHOLDER, EINVALID_REQ_ID);
@@ -324,7 +324,7 @@ module free_tunnel_rooch::atomic_mint {
         let amount = req_helpers::amountFrom<CoinType>(&reqId);
         let _tokenIndex = req_helpers::tokenIndexFrom<CoinType>(&reqId);
 
-        let coinInside = &mut storeForCoinAndMinterCap.burningCoins;
+        let coinInside = &mut coinStorage.burningCoins;
         let coinCancelled = coin_store::withdraw(coinInside, amount);
 
         account_coin_store::deposit(proposerAddress, coinCancelled);


### PR DESCRIPTION
1. Index issue with `removeProposer`. A similar bug was previously identified in Sui's audit but remains unaddressed in Aptos/Rooch.  
2. In `removeToken`, `lockedCoins` should not be withdrawn to prevent potential rug pulls by admins.  
3. Condition validation issues:  
    1. Incorrect `assert` usage in `proposeLock` and `proposeMintPrivate`.  
    2. Incorrect `assertFromChainOnly` in `proposeBurnForMint`.  
    3. Incomplete threshold condition checks in `initExecutorsInternal`.  
    4. Incomplete threshold checks and missing `checkExecutorsNotDuplicated` in `updateExecutors`.  
4. Naming adjustments:  
    - `AtomicMintGeneralStorage` → `AtomicMintStorage`  
    - `StoreForCoinAndMinterCap` → `CoinStorage`  
    - `minterCapOptObj` → `minterCap`  
    - `AtomicLockGeneralStorage` → `AtomicLockStorage`  
    - `StoreForCoin` → `CoinStorage`  
5. Other issues:  
    1. Complete the `ExecutorsUpdated` event implementation.
    2. Align `destroyMinterCap` placement with Sui's implementation. 