### PR TITLE
Fix/aptos

### DIFF
--- a/sources/Permissions.move
+++ b/sources/Permissions.move
@@ -136,7 +136,7 @@ module free_tunnel_aptos::permissions {
         let len = vector::length(&storeP._proposerList);
         if (index < len) {
             let lastProposer = *vector::borrow(&storeP._proposerList, len - 1);
-            *vector::borrow_mut(&mut storeP._proposerList, index) = lastProposer;
+            *vector::borrow_mut(&mut storeP._proposerList, index - 1) = lastProposer;
             *table::borrow_mut(&mut storeP._proposerIndex, lastProposer) = index;
         };
         vector::pop_back(&mut storeP._proposerList);

--- a/sources/Permissions.move
+++ b/sources/Permissions.move
@@ -86,6 +86,14 @@ module free_tunnel_aptos::permissions {
         proposer: address,
     }
 
+    #[event]
+    struct ExecutorsUpdated has drop, store {
+        executors: vector<vector<u8>>,
+        threshold: u64,
+        activeSince: u64,
+        exeIndex: u64,
+    }
+
 
     // =========================== Functions ===========================
     public(friend) fun assertOnlyAdmin(sender: &signer) acquires PermissionsStorage {
@@ -153,6 +161,7 @@ module free_tunnel_aptos::permissions {
         vector::push_back(&mut storeP._executorsForIndex, executors);
         vector::push_back(&mut storeP._exeThresholdForIndex, threshold);
         vector::push_back(&mut storeP._exeActiveSinceForIndex, 1);
+        event::emit(ExecutorsUpdated { executors, threshold, activeSince: 1, exeIndex: 0 });
     }
 
     public entry fun updateExecutors(
@@ -222,7 +231,8 @@ module free_tunnel_aptos::permissions {
             *vector::borrow_mut(&mut storeP._executorsForIndex, newIndex) = newExecutors;
             *vector::borrow_mut(&mut storeP._exeThresholdForIndex, newIndex) = threshold;
             *vector::borrow_mut(&mut storeP._exeActiveSinceForIndex, newIndex) = activeSince;
-        }
+        };
+        event::emit(ExecutorsUpdated { executors: newExecutors, threshold, activeSince, exeIndex: newIndex });
     }
 
 

--- a/sources/Permissions.move
+++ b/sources/Permissions.move
@@ -146,8 +146,10 @@ module free_tunnel_aptos::permissions {
     public(friend) fun initExecutorsInternal(executors: vector<vector<u8>>, threshold: u64) acquires PermissionsStorage {
         let storeP = borrow_global_mut<PermissionsStorage>(@free_tunnel_aptos);
         assertEthAddressList(&executors);
+        assert!(threshold <= vector::length(&executors), ENOT_MEET_THRESHOLD);
         assert!(vector::length(&storeP._exeActiveSinceForIndex) == 0, EEXECUTORS_ALREADY_INITIALIZED);
         assert!(threshold > 0, ETHRESHOLD_MUST_BE_GREATER_THAN_ZERO);
+        checkExecutorsNotDuplicated(executors);
         vector::push_back(&mut storeP._executorsForIndex, executors);
         vector::push_back(&mut storeP._exeThresholdForIndex, threshold);
         vector::push_back(&mut storeP._exeActiveSinceForIndex, 1);
@@ -165,6 +167,7 @@ module free_tunnel_aptos::permissions {
     ) acquires PermissionsStorage {
         assertEthAddressList(&newExecutors);
         assert!(threshold > 0, ETHRESHOLD_MUST_BE_GREATER_THAN_ZERO);
+        assert!(threshold <= vector::length(&newExecutors), ENOT_MEET_THRESHOLD);
         assert!(
             activeSince > now_seconds() + 36 * 3600,  // 36 hours
             EACTIVE_SINCE_SHOULD_AFTER_36H,
@@ -173,6 +176,7 @@ module free_tunnel_aptos::permissions {
             activeSince < now_seconds() + 120 * 3600,  // 5 days
             EACTIVE_SINCE_SHOULD_WITHIN_5D,
         );
+        checkExecutorsNotDuplicated(newExecutors);
 
         let msg = vector::empty<u8>();
         vector::append(&mut msg, ETH_SIGN_HEADER());
@@ -282,10 +286,26 @@ module free_tunnel_aptos::permissions {
         };
     }
 
+    fun checkExecutorsNotDuplicated(executors: vector<vector<u8>>) {
+        let i = 0;
+        while (i < vector::length(&executors)) {
+            let executor = *vector::borrow(&executors, i);
+            let j = 0;
+            while (j < i) {
+                assert!(*vector::borrow(&executors, j) != executor, EDUPLICATED_EXECUTORS);
+                j = j + 1;
+            };
+            i = i + 1;
+        };
+    }
+
     fun checkExecutorsForIndex(executors: &vector<vector<u8>>, exeIndex: u64) acquires PermissionsStorage {
         let storeP = borrow_global_mut<PermissionsStorage>(@free_tunnel_aptos);
         assertEthAddressList(executors);
-        assert!(vector::length(&storeP._exeActiveSinceForIndex) > exeIndex + 1, ENOT_MEET_THRESHOLD);
+        assert!(
+            vector::length(executors) >= *vector::borrow(&storeP._exeThresholdForIndex, exeIndex), 
+            ENOT_MEET_THRESHOLD
+        );
         let activeSince = *vector::borrow(&storeP._exeActiveSinceForIndex, exeIndex);
         assert!(activeSince < now_seconds(), EEXECUTORS_NOT_YET_ACTIVE);
 

--- a/sources/lock/AtomicLockContract.move
+++ b/sources/lock/AtomicLockContract.move
@@ -115,7 +115,7 @@ module free_tunnel_aptos::atomic_lock {
         req_helpers::checkCreatedTimeFrom(&reqId);
         let action = req_helpers::actionFrom(&reqId);
         assert!(action & 0x0f == 1, ENOT_LOCK_MINT);
-        assert!(table::contains(&storeA.proposedLock, reqId), EINVALID_REQ_ID);
+        assert!(!table::contains(&storeA.proposedLock, reqId), EINVALID_REQ_ID);
 
         let proposerAddress = signer::address_of(proposer);
         assert!(proposerAddress != EXECUTED_PLACEHOLDER, EINVALID_PROPOSER);

--- a/sources/lock/AtomicLockContract.move
+++ b/sources/lock/AtomicLockContract.move
@@ -87,21 +87,21 @@ module free_tunnel_aptos::atomic_lock {
     ) {
         permissions::assertOnlyAdmin(admin);
         req_helpers::addTokenInternal<CoinType>(tokenIndex);
-        let coinStorage = CoinStorage<CoinType> {
-            lockedCoins: coin::zero<CoinType>(),
-        };
-        move_to(admin, coinStorage);
+        if (!exists<CoinStorage<CoinType>>(@free_tunnel_aptos)) {
+            let coinStorage = CoinStorage<CoinType> {
+                lockedCoins: coin::zero<CoinType>(),
+            };
+            move_to(admin, coinStorage);
+        }
     }
-
+    
 
     public entry fun removeToken<CoinType>(
         admin: &signer,
         tokenIndex: u8,
-    ) acquires CoinStorage {
+    ) {
         permissions::assertOnlyAdmin(admin);
         req_helpers::removeTokenInternal(tokenIndex);
-        let CoinStorage { lockedCoins } = move_from<CoinStorage<CoinType>>(@free_tunnel_aptos);
-        coin::deposit(signer::address_of(admin), lockedCoins);
     }
 
 

--- a/sources/mint/AtomicMintContract.move
+++ b/sources/mint/AtomicMintContract.move
@@ -159,7 +159,7 @@ module free_tunnel_aptos::atomic_mint {
     ) acquires AtomicMintGeneralStorage {
         req_helpers::checkCreatedTimeFrom(&reqId);
         let storeA = borrow_global_mut<AtomicMintGeneralStorage>(@free_tunnel_aptos);
-        assert!(table::contains(&storeA.proposedMint, reqId), EINVALID_REQ_ID);
+        assert!(!table::contains(&storeA.proposedMint, reqId), EINVALID_REQ_ID);
         assert!(recipient != EXECUTED_PLACEHOLDER, EINVALID_RECIPIENT);
 
         req_helpers::amountFrom<CoinType>(&reqId);
@@ -230,7 +230,7 @@ module free_tunnel_aptos::atomic_mint {
         proposer: &signer,
         reqId: vector<u8>,
     ) acquires AtomicMintGeneralStorage, StoreForCoinAndMinterCap {
-        req_helpers::assertToChainOnly(&reqId);
+        req_helpers::assertFromChainOnly(&reqId);
         assert!(req_helpers::actionFrom(&reqId) & 0x0f == 3, ENOT_BURN_MINT);
         proposeBurnPrivate<CoinType>(proposer, reqId);
     }


### PR DESCRIPTION
1. Index issue with `removeProposer`. A similar bug was previously identified in Sui's audit but remains unaddressed in Aptos/Rooch.  
2. In `removeToken`, `lockedCoins` should not be withdrawn to prevent potential rug pulls by admins.  
3. Condition validation issues:  
    1. Incorrect `assert` usage in `proposeLock` and `proposeMintPrivate`.  
    2. Incorrect `assertFromChainOnly` in `proposeBurnForMint`.  
    3. Incomplete threshold condition checks in `initExecutorsInternal`.  
    4. Incomplete threshold checks and missing `checkExecutorsNotDuplicated` in `updateExecutors`.  
4. Naming adjustments:  
    - `AtomicMintGeneralStorage` → `AtomicMintStorage`  
    - `StoreForCoinAndMinterCap` → `CoinStorage`  
    - `minterCapOptObj` → `minterCap`  
    - `AtomicLockGeneralStorage` → `AtomicLockStorage`  
    - `StoreForCoin` → `CoinStorage`  
5. Other issues:  
    1. Complete the `ExecutorsUpdated` event implementation.